### PR TITLE
チャットグループのルーティング設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'messages#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update]
 end


### PR DESCRIPTION
# What
グループチャットのルーティングを設定。
new, create, edit, updateを追加。

# Why
グループチャットのリクエスト（投稿、編集など）からコントローラーに導くため。